### PR TITLE
feat(cron): rework acme.s cron jobs to be able to switch gcloud projects

### DIFF
--- a/tasks/install_acmesh.yml
+++ b/tasks/install_acmesh.yml
@@ -4,9 +4,9 @@
     path: "{{ item }}"
     state: directory
   with_items:
-  - "{{ acme_paths['install_path'] }}"
-  - "{{ acme_paths['cert_path'] }}"
-  - "{{ acme_paths['download_path'] }}"
+    - "{{ acme_paths['install_path'] }}"
+    - "{{ acme_paths['cert_path'] }}"
+    - "{{ acme_paths['download_path'] }}"
 
 - name: Install prerequisites
   package:
@@ -35,14 +35,31 @@
   changed_when: false
   when: acme_install_path.stat.exists
 
-- name: Create cron job
+- name: Create GCloud cron job
+  cron:
+    name: Acme.sh GCloud certificate renew
+    minute: '0'
+    hour: '2'
+    user: root
+    job: "GCLOUDSDK_CORE_PROJECT={{ item.project }} {{ acme_paths['install_path'] }}/acme.sh --renew --domain {{ item.domain }} --home {{ acme_paths['install_path'] }} &>> {{ acme_paths['log_file'] }}"
+  with_items:
+    - "{{ acme_domains }}"
+  when:
+    - acme_install_path.stat.exists
+    - item.provider == 'dns_gcloud'
+
+- name: Create other cron job
   cron:
     name: Acme.sh certificate renew
     minute: '0'
     hour: '2'
     user: root
-    job: "{{ acme_paths['install_path'] }}/acme.sh --cron --home {{ acme_paths['install_path'] }} &>> {{ acme_paths['log_file'] }}"
-  when: acme_install_path.stat.exists
+    job: "{{ acme_paths['install_path'] }}/acme.sh --renew --domain {{ item.domain }} --home {{ acme_paths['install_path'] }} &>> {{ acme_paths['log_file'] }}"
+  with_items:
+    - "{{ acme_domains }}"
+  when:
+    - acme_install_path.stat.exists
+    - item.provider != 'dns_gcloud'
 
 - name: Copy custom dnsapi scripts to the install_path
   copy:

--- a/tasks/install_acmesh.yml
+++ b/tasks/install_acmesh.yml
@@ -35,13 +35,13 @@
   changed_when: false
   when: acme_install_path.stat.exists
 
-- name: Create GCloud cron job
+- name: Create gcloud cron job
   cron:
-    name: Acme.sh GCloud certificate renew
+    name: Acme.sh gcloud certificate renew
     minute: '0'
     hour: '2'
     user: root
-    job: "GCLOUDSDK_CORE_PROJECT={{ item.project }} {{ acme_paths['install_path'] }}/acme.sh --renew --domain {{ item.domain }} --home {{ acme_paths['install_path'] }} &>> {{ acme_paths['log_file'] }}"
+    job: "CLOUDSDK_CORE_PROJECT={{ item.project }} {{ acme_paths['install_path'] }}/acme.sh --renew --domain {{ item.domain }} --home {{ acme_paths['install_path'] }} &>> {{ acme_paths['log_file'] }}"
   with_items:
     - "{{ acme_domains }}"
   when:

--- a/tasks/install_acmesh.yml
+++ b/tasks/install_acmesh.yml
@@ -35,31 +35,16 @@
   changed_when: false
   when: acme_install_path.stat.exists
 
-- name: Create gcloud cron job
+- name: Create acme cron job
   cron:
-    name: Acme.sh gcloud certificate renew
+    name: Acme.sh {{ item.domain }} certificate renew
     minute: '0'
     hour: '2'
     user: root
-    job: "CLOUDSDK_CORE_PROJECT={{ item.project }} {{ acme_paths['install_path'] }}/acme.sh --renew --domain {{ item.domain }} --home {{ acme_paths['install_path'] }} &>> {{ acme_paths['log_file'] }}"
+    job: "{{ (item.provider == 'dns_gcloud') | ternary('CLOUDSDK_CORE_PROJECT=' + (item.project | default('')) + ' ', '') }}{{ acme_paths['install_path'] }}/acme.sh --renew --domain {{ item.domain }} --home {{ acme_paths['install_path'] }} &>> {{ acme_paths['log_file'] }}"
   with_items:
     - "{{ acme_domains }}"
-  when:
-    - acme_install_path.stat.exists
-    - item.provider == 'dns_gcloud'
-
-- name: Create other cron job
-  cron:
-    name: Acme.sh certificate renew
-    minute: '0'
-    hour: '2'
-    user: root
-    job: "{{ acme_paths['install_path'] }}/acme.sh --renew --domain {{ item.domain }} --home {{ acme_paths['install_path'] }} &>> {{ acme_paths['log_file'] }}"
-  with_items:
-    - "{{ acme_domains }}"
-  when:
-    - acme_install_path.stat.exists
-    - item.provider != 'dns_gcloud'
+  when: acme_install_path.stat.exists
 
 - name: Copy custom dnsapi scripts to the install_path
   copy:


### PR DESCRIPTION
Introducing the second cron job which is run only for gcloud domains an in which `GCLOUDSDK_CORE_PROJECT` variable is used to reflect gcloud project per domain.