### PR TITLE
feat(acme): run handler only once

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,3 +10,8 @@
   include_tasks: provision_certificates.yaml
   with_items:
     - "{{ acme_domains }}"
+
+- name: Run handler
+  notify: "HANDLER: Run {{ acme_reload_cmd }}"
+  when: acme_run_handler
+

--- a/tasks/provision_certificates.yaml
+++ b/tasks/provision_certificates.yaml
@@ -32,8 +32,8 @@
       --reloadcmd "{{ acme_reload_cmd }}"
       {{ '--force' if acme_force else '' }}
       {{ '--test' if acme_test or item.acme_test|default(false) else ''}}
-  notify:
-    - "HANDLER: Run {{ acme_reload_cmd }}"
+  set_fact:
+    acme_run_handler: true
   when: |
     (acme_enabled and acme_domain_certificate.stat.exists == false) or
     (acme_enabled and acme_force is defined and acme_force )


### PR DESCRIPTION
- after all certs in the loop are issued, this will help to improve stability of the application using the certs (in this case GitLab)